### PR TITLE
Using Math.sin () instead of FloatMath.sin ()

### DIFF
--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
@@ -300,7 +300,7 @@ public class CustomViewAbove extends ViewGroup {
 	float distanceInfluenceForSnapDuration(float f) {
 		f -= 0.5f; // center the values about 0.
 		f *= 0.3f * Math.PI / 2.0f;
-		return (float) FloatMath.sin(f);
+		return (float) Math.sin(f);
 	}
 
 	public int getDestScrollX(int page) {


### PR DESCRIPTION
Android Studio API23 does not support FloatMath.sin (), resulting in compilation failure. Issuess has a lot of people mentioned this problem.